### PR TITLE
fix argument typo in BertForMaskedLM

### DIFF
--- a/NEZHA-PyTorch/modeling_nezha.py
+++ b/NEZHA-PyTorch/modeling_nezha.py
@@ -918,7 +918,7 @@ class BertForMaskedLM(BertPreTrainedModel):
     def forward(self, input_ids, token_type_ids=None, attention_mask=None, masked_lm_labels=None,
                 output_att=False, infer=False):
         sequence_output, _ = self.bert(input_ids, token_type_ids, attention_mask,
-                                       output_all_encoded_layers=True, output_att=output_att)
+                                       output_all_encoded_layers=True)#, output_att=output_att)
 
         if output_att:
             sequence_output, att_output = sequence_output

--- a/NEZHA-PyTorch/modeling_nezha.py
+++ b/NEZHA-PyTorch/modeling_nezha.py
@@ -918,7 +918,7 @@ class BertForMaskedLM(BertPreTrainedModel):
     def forward(self, input_ids, token_type_ids=None, attention_mask=None, masked_lm_labels=None,
                 output_att=False, infer=False):
         sequence_output, _ = self.bert(input_ids, token_type_ids, attention_mask,
-                                       output_all_encoded_layers=True)#, output_att=output_att)
+                                       output_all_encoded_layers=True, output_attention_mask=output_att)
 
         if output_att:
             sequence_output, att_output = sequence_output


### PR DESCRIPTION
https://github.com/huawei-noah/Pretrained-Language-Model/blob/a8a705e9c8c952e078b45d1091d3f0ed161483d8/NEZHA-PyTorch/modeling_nezha.py#L921

rename `output_att` to `output_attention_mask`